### PR TITLE
CMake: Set COMPATIBILITY correctly

### DIFF
--- a/src/bridgefmtspihelper/CMakeLists.txt
+++ b/src/bridgefmtspihelper/CMakeLists.txt
@@ -55,7 +55,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     bridgefmtspihelperConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake


### PR DESCRIPTION
Not only that SameMinorVersion makes no sense - elser versions of cmake don't
support it.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>