### PR TITLE
CMake do not hard pin parts of include path

### DIFF
--- a/src/bridgefmtspihelper/CMakeLists.txt
+++ b/src/bridgefmtspihelper/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(bridgefmtspihelper
 # announce headers - target perspective
 target_include_directories(bridgefmtspihelper
     PUBLIC
-    $<INSTALL_INTERFACE:include/bridgefmtspihelper>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/bridgefmtspihelper>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>