### PR TITLE
workflows/triggerMetaUpdates.yml: Update trigger workflow handling

### DIFF
--- a/.github/workflows/triggerMetaUpdates.yml
+++ b/.github/workflows/triggerMetaUpdates.yml
@@ -23,4 +23,5 @@ jobs:
           workflow_file_name: updateSubmodule.yml
           inputs: '{"submodule" : "${{ env.MODULENAME }}"}'  
           ref: master
-
+          wait_workflow: false
+          propagate_failure: false


### PR DESCRIPTION
* Do not wait for the triggered workflow to finish. Because, this check is asynchronous and sometimes causes a racing condition, meaning, it checks if the triggered workflow is finished successfully even before it started.
* Do not propagate success/failure of triggered workflow to this current workflow. Since we don't wait for triggered workflow to finish, propagating it's status doesn't make sense.